### PR TITLE
Close #2 by using aesthetically cleaner stylesheet

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1,47 +1,40 @@
-body {
-    background-color: black;
+html {
     background-image: url(dawn-bkg.jpg);
+    background-color: #334477;
     background-size: cover;
     background-position: center 80%;
     background-attachment: fixed;
     color: white;
-    padding-bottom: 200px;
     margin: 0px;
+}
+body {
+    background: rgba(0,0,0,0.5);
+    max-width: 45em;
+    margin: 0 auto;
+    padding: 0.001em 1em 10em;
 }
 
 h1 {
     text-align: center;
     color: yellow;
     font-size: 40pt;
-    text-shadow: 0 0 25px yellow;
-    margin-bottom: 30px;
-    margin-top: 0px;
+    margin: 30px 0;
 }
 
 h2 {
     text-align:center;
-    min-width: 40%;
-    width: fit-content;
-    margin: 1em auto;
-    background: rgba(0,0,0,0.3);
-    padding: 0.25em 1em;
-    white-space: nowrap;
-    box-shadow: 0px 0px 30px 0px rgba(0,0,0,0.6);
-    border-radius: 30px;
+    margin: 1em 0;
 }
 
 p,ul,table,pre {
     margin: auto ;
-    background: rgba(0,0,0,0.6);
 }
 
 p,pre {
     padding: 0.5em;
-    width: 80%;
 }
 
 ul {
-    width: 50%;
     padding: 1em;
     padding-left: 2em;
 }
@@ -52,6 +45,7 @@ a {
 
 table {
     width: 100%;
+    border-collapse: collapse;
 }
 
 td {
@@ -66,21 +60,24 @@ td {
 
 .header {
     width: 100%;
-    background: black;
-    padding-top: .5em;
-    padding-bottom: 4em;
-    padding: .5em;
-    background: linear-gradient(to bottom,
-                                rgba(20,0,20,1) 0%,
-                                rgba(90,15,50,0.8) 60%,
-                                rgba(90,15,50,0) 100%);
+    margin-bottom: 1em;
+    text-align: center;
 }
 .header a {
-    width: 23%;
+    min-width: 21%;
+    background: rgba(153,17,81,0.5);
+    padding: 0.5em 0;
+    margin-right: 1.5%;
+    border-bottom-left-radius: 1em;
+    border-bottom-right-radius: 1em;
     text-decoration: none;
     text-align:center;
     display: inline-block;
     color: #aee;
     font-weight: bold;
-    padding-bottom: 1em;
+}
+.header a:last-child { margin-right: 0; }
+
+a[href^="https://github.com/SecularSolstice/SecularSolstice.github.io/"] { /*This should only get the "raw git" links */
+    text-align: center; /*This doesn't actually work to center the text, but it should. */
 }

--- a/theme.css
+++ b/theme.css
@@ -78,6 +78,9 @@ td {
 }
 .header a:last-child { margin-right: 0; }
 
-a[href^="https://github.com/SecularSolstice/SecularSolstice.github.io/"] { /*This should only get the "raw git" links */
-    text-align: center; /*This doesn't actually work to center the text, but it should. */
+body>a[href^="https://github.com/SecularSolstice/SecularSolstice.github.io"] { /*This should only get the "raw git" links */
+    text-align: center;
+    display: block;
+    font-size: 1.25em;
+    margin: 1em 0;
 }


### PR DESCRIPTION
- puts all body text, including "raw git" link, in box with unified width and background opacity
- makes header stop being wider than window
- collapses table borders
- turns header into tabs to increase visual clarity
- reduces unnecessary glow effects