### PR TITLE
Remove a duplicate phrase and a special character in Uplift lyrics

### DIFF
--- a/Uplift/gen/Uplift-lyrics.txt
+++ b/Uplift/gen/Uplift-lyrics.txt
@@ -1,6 +1,6 @@
    
    
-Hands chip the flint, light the fire, skin the kill flint, light the fire, skin the kill
+Hands chip the flint, light the fire, skin the kill
 Feet move the tribe track the   herd with a will   
 Human-kind struggles, on the edge of histo ry
 Time to settle down, time to grow, time to breed down, time to  grow, time to breed..

--- a/Uplift/gen/Uplift-lyrics.txt
+++ b/Uplift/gen/Uplift-lyrics.txt
@@ -26,7 +26,7 @@ one... that... makes us grow
 Light push the sails, read the  data, cities  glow   
 Hands type the keys, tap the screen, out we go!   
 Our voices carry round the world and into space   
-Send us out to colonize another place¸   
+Send us out to colonize another place.   
    (skip)
 Hands, make the tools, light fire, plant the grain   
 Feet, track the herd. Build a world. Begin again...   

--- a/Uplift/gen/Uplift-lyrics.txt
+++ b/Uplift/gen/Uplift-lyrics.txt
@@ -3,7 +3,7 @@
 Hands chip the flint, light the fire, skin the kill
 Feet move the tribe track the   herd with a will   
 Human-kind struggles, on the edge of histo ry
-Time to settle down, time to grow, time to breed down, time to  grow, time to breed..
+Time to settle down, time to grow, time to breed...
 ...   (skip)
 Plow tills the soil, plants the seed, pray for rain   
 Scythe reaps the wheat, to the  mill, to grind the grain   


### PR DESCRIPTION
There was a duplicate phrase in the first line, and a [cedilla](https://en.wikipedia.org/wiki/Cedilla) instead of a period later on.

When I ran `make all`, it didn't incorporate the README for the song into Uplift/gen/index.html. It sometimes did the same thing for other songs as well, and for others didn't include the lyrics instead. I'm not sure if there's a problem with a makefile or if I did something wrong. But in any case, it's probably easier for you to autogen Uplift than for me figure this out.