### PR TITLE
'banishes doubt' -> 'challenges doubt'

### DIFF
--- a/songs/Somebody_Will/gen/Somebody_Will-lyrics.txt
+++ b/songs/Somebody_Will/gen/Somebody_Will-lyrics.txt
@@ -57,7 +57,7 @@ We’ve planned too many wonders for one little star.
 Though often the present may seem too complacent to take us that far.
 
 But I’ll tell the story and I’ll draw the picture
-And I’ll sing the anthem that banishes doubt,
+And I’ll sing the anthem that challenges doubt,
 And host the convention that summons the family
 That carries the fire that never burns out
 There are so many chances to give up the journey,


### PR DESCRIPTION
The 'banishes doubt' bit in Somebody Will had been back-of-mind bothering me for years, seeing as one of the core beliefs here is that (properly-calibrated) doubt is useful, but I never gave it enough attention to come up with an alternative.
The Bay Area Solstice this year had it as 'challenges doubt' instead, which I think is just better and should be adopted as the default.