### PR TITLE
fixed carriage return included in autocomp.js

### DIFF
--- a/misc/gen/autocomp.js
+++ b/misc/gen/autocomp.js
@@ -2054,8 +2054,8 @@ content = {
   ],
 
   'Verlieren_German': [
-    "Verlieren",
-    "By Eva Simon",
+    "Verlieren",
+    "By Eva Simon",
     "[speech]",
   ],
 

--- a/scripts/gather_lists.sh
+++ b/scripts/gather_lists.sh
@@ -9,14 +9,14 @@ echo 'content = {'
 for i in  songs/*/README.md; do
     echo
     echo "  '$i': [" | sed 's@/README.md@@' | sed 's@songs/@@'
-    grep '#' $i | head -n 3 | sed 's/"/\\"/g' | sed 's/^#* */    "/' | sed 's/$/",/'
+    grep '#' $i | head -n 3 | sed -e 's/"/\\"/g' -e 's/^#* */    "/' -e 's/$/",/' -e 's/\r//'
     echo '  ],'
 done
 
 for i in  speeches/*.md; do
     echo
     echo "  '$i': [" | sed 's@speeches/@@' | sed 's/.md//'
-    grep '#' $i | head -n 2 | sed 's/^#* */    "/' | sed 's/$/",/'
+    grep '#' $i | head -n 2 | sed -e 's/^#* */    "/' -e 's/$/",/' -e 's/\r//'
     echo '    "[speech]",'
     echo '  ],'
 done


### PR DESCRIPTION
fixed carriage return included in `autocomp.js` causing the script to fail loading in browser.

files (ex: songs and speeches) that contains crlf line endings caused `gather_lists.sh` to include cr in the generated json/js. i added a sed command to remove cr from song/speeches names.

you might additionally want to add some check to prevent prs to add files with crlf and cr line endings.
